### PR TITLE
Add support for ANDROID_SDK_ROOT

### DIFF
--- a/core/findAndroidEmulators.js
+++ b/core/findAndroidEmulators.js
@@ -1,4 +1,27 @@
 const { execSync } = require('child_process')
+const fs = require('fs')
+
+function isValidAndroidSdk(sdkRoot) {
+  if (!sdkRoot) return false
+  // not sure if this is a good test for a valid sdk
+  // but since we only use emulator/emulator, it should be good enough
+  const emulator = `${sdkRoot}/emulator/emulator`
+  return fs.existsSync(emulator)
+}
+
+function getAndroidSdkRoot() {
+  // see https://developer.android.com/studio/command-line/variables
+  const { ANDROID_HOME } = process.env
+  if (isValidAndroidSdk(ANDROID_HOME)) return ANDROID_HOME
+
+  const { ANDROID_SDK_ROOT } = process.env
+  if (isValidAndroidSdk(ANDROID_SDK_ROOT)) return ANDROID_SDK_ROOT
+
+  console.error(
+    `Can not find a valid android sdk in ANDROID_HOME (${ANDROID_HOME}) or ANDROID_SDK_ROOT (${ANDROID_SDK_ROOT})`
+  )
+  throw new Error('Android sdk not found')
+}
 
 module.exports = async function findAndroidEmulators(asyncCallback) {
   try {
@@ -13,7 +36,7 @@ module.exports = async function findAndroidEmulators(asyncCallback) {
 
     const { name } = await asyncCallback(devices)
 
-    return execSync(`${process.env.ANDROID_HOME}/emulator/emulator @${name}`)
+    return execSync(`${getAndroidSdkRoot()}/emulator/emulator @${name}`)
   } catch (error) {
     console.error('Can not find any android devices') // eslint-disable-line
   }


### PR DESCRIPTION
ANDROID_HOME is deprecated, see https://developer.android.com/studio/command-line/variables

Without this, if ANDROID_SDK_ROOT is defined but not ANDROID_HOME, clisim crashes:

```text
/bin/sh: undefined/emulator/emulator: No such file or directory
Can not find any android devices
```

